### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for thanos-receive-controller-acm-214

### DIFF
--- a/Containerfile.operator
+++ b/Containerfile.operator
@@ -18,7 +18,8 @@ USER 65534
 ENTRYPOINT ["/usr/bin/thanos-receive-controller"]
 
 LABEL com.redhat.component="thanos-receive-controller" \
-  name="thanos-receive-controller" \
+  name="rhacm2/thanos-receive-controller-rhel9" \
+  cpe="cpe:/a:redhat:acm:2.14::el9" \
   summary="thanos-receive-controller" \
   io.openshift.expose-services="" \
   io.openshift.tags="data,images" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
