### PR TITLE
Add GitHub repository labels to container images

### DIFF
--- a/Containerfile.operator
+++ b/Containerfile.operator
@@ -18,6 +18,7 @@ USER 65534
 ENTRYPOINT ["/usr/bin/thanos-receive-controller"]
 
 LABEL com.redhat.component="thanos-receive-controller" \
+      url="https://github.com/stolostron/thanos-receive-controller" \
   name="thanos-receive-controller" \
   summary="thanos-receive-controller" \
   io.openshift.expose-services="" \


### PR DESCRIPTION
This pull request adds the repository URL as the 'url' label to container images.

**Related Issue:** https://issues.redhat.com/browse/ACM-23275

**Epic Goal:** All ACM and MCE container images should define the url label pointing to their source repository instead of the generic 'https://www.redhat.com' value.

**Target Branch:** release-2.15

**Components affected:** thanos-receive-controller

**Branch details:** thanos-receive-controller (branch: release-2.15)

**Label added:**
- url: https://github.com/stolostron/thanos-receive-controller

This change improves traceability and helps identify the source repository for each container image, which is especially important for components like kube-rbac-proxy that exist in multiple organizations.