### PR TITLE
Add Dockerfile.art for ART/Brew build migration

### DIFF
--- a/Dockerfile.art
+++ b/Dockerfile.art
@@ -1,0 +1,30 @@
+# Copyright Contributors to the Open Cluster Management project
+# Licensed under the Apache License 2.0
+
+FROM registry-proxy.engineering.redhat.com/rh-osbs/openshift-golang-builder:v1.25.8 AS builder
+
+WORKDIR /workspace
+
+COPY . .
+
+RUN go mod vendor && CGO_ENABLED=1 GOEXPERIMENT=strictfipsruntime go build -mod vendor -v -o thanos-receive-controller 
+
+FROM registry-proxy.engineering.redhat.com/ubi9/ubi-minimal:latest
+
+COPY --from=builder /workspace/thanos-receive-controller /usr/bin/thanos-receive-controller
+
+USER 65534
+
+ENTRYPOINT ["/usr/bin/thanos-receive-controller"]
+
+LABEL com.redhat.component="thanos-receive-controller" \
+      url="https://github.com/stolostron/thanos-receive-controller" \
+  name="rhacm2/thanos-receive-controller-rhel9" \
+  cpe="cpe:/a:redhat:acm:2.16::el9" \
+  summary="thanos-receive-controller" \
+  io.openshift.expose-services="" \
+  io.openshift.tags="data,images" \
+  io.k8s.display-name="thanos-receive-controller" \
+  maintainer="" \
+  description="thanos-receive-controller" \
+  io.k8s.description="thanos-receive-controller"


### PR DESCRIPTION
HYPBLD-847: ACM 2.16: Create Dockerfile.art + ocp-build-data config
https://redhat.atlassian.net/browse/HYPBLD-847

Create the build configuration required for ART to build ACM 2.16 components.

Dockerfile.art files (50 repos):                                                                     
- Create Dockerfile.art in each ACM repo on release-2.16 branch                                      
- Use existing Dockerfile.rhtap as starting point                                                    
- Change registry to registry-proxy.engineering.redhat.com
- Add FIPS flags (GOEXPERIMENT=strictfipsruntime, CGO_ENABLED=1)                                     
Note: multiclusterhub-operator uses brew.registry — needs manual FROM line conversion              

Signed-off-by: Brian Smith (briansmi@redhat.com)