### PR TITLE
Add FIPS build flags to Dockerfile

### DIFF
--- a/Containerfile.operator
+++ b/Containerfile.operator
@@ -7,7 +7,7 @@ WORKDIR /workspace
 
 COPY . .
 
-RUN go mod vendor && go build -mod vendor -v -o thanos-receive-controller 
+RUN go mod vendor && CGO_ENABLED=1 GOEXPERIMENT=strictfipsruntime go build -mod vendor -v -o thanos-receive-controller 
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 


### PR DESCRIPTION
Add CGO_ENABLED=1 and GOEXPERIMENT=strictfipsruntime to go build, make, and promu build lines for FIPS compliance.

JIRA: HYPBLD-847

**Related Issue:**  stolostron/backlog#<ISSUE_NUMBER>

### Description of changes
