### PR TITLE
[release-2.11] Build: bump ubi to version 9

### DIFF
--- a/Containerfile.operator
+++ b/Containerfile.operator
@@ -9,7 +9,7 @@ COPY . .
 
 RUN go mod vendor && go build -mod vendor -v -o thanos-receive-controller 
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 COPY --from=builder /workspace/thanos-receive-controller /usr/bin/thanos-receive-controller
 

--- a/Dockerfile.prow
+++ b/Dockerfile.prow
@@ -6,7 +6,7 @@ COPY . .
 
 RUN  make thanos-receive-controller
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 COPY --from=builder /workspace/thanos-receive-controller /usr/bin/thanos-receive-controller
 


### PR DESCRIPTION
As required by the Go 1.25 builders.