### PR TITLE
fix: patch CVE-2026-42151 in github.com/prometheus/prometheus

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -203,6 +203,10 @@ require (
 )
 
 replace (
+	// CVE-2026-42151: Azure AD OAuth client_secret exposed via config API.
+	// Upstream fix is in v0.311.3 but requires thanos update (tsdb/errors removed in v0.310.0).
+	// This replace points to stolostron/prometheus with the fix cherry-picked onto v0.308.0.
+	github.com/prometheus/prometheus => github.com/stolostron/prometheus v0.0.0-20260707114222-c54e4c457006
 	github.com/vimeo/galaxycache => github.com/thanos-community/galaxycache v0.0.0-20211122094458-3a32041a1f1e
 	// Overriding to use latest commit.
 	gopkg.in/alecthomas/kingpin.v2 => github.com/alecthomas/kingpin v1.3.8-0.20210301060133-17f40c25f497

--- a/go.sum
+++ b/go.sum
@@ -1040,8 +1040,6 @@ github.com/prometheus/procfs v0.7.3/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1
 github.com/prometheus/procfs v0.8.0/go.mod h1:z7EfXMXOkbkqb9IINtpCn86r/to3BnA0uaxHdg830/4=
 github.com/prometheus/procfs v0.16.1 h1:hZ15bTNuirocR6u0JZ6BAHHmwS1p8B4P6MRqxtzMyRg=
 github.com/prometheus/procfs v0.16.1/go.mod h1:teAbpZRB1iIAJYREa1LsoWUXykVXA1KlTmWl8x/U+Is=
-github.com/prometheus/prometheus v0.308.0 h1:kVh/5m1n6m4cSK9HYTDEbMxzuzCWyEdPdKSxFRxXj04=
-github.com/prometheus/prometheus v0.308.0/go.mod h1:xXYKzScyqyFHihpS0UsXpC2F3RA/CygOs7wb4mpdusE=
 github.com/prometheus/sigv4 v0.3.0 h1:QIG7nTbu0JTnNidGI1Uwl5AGVIChWUACxn2B/BQ1kms=
 github.com/prometheus/sigv4 v0.3.0/go.mod h1:fKtFYDus2M43CWKMNtGvFNHGXnAJJEGZbiYCmVp/F8I=
 github.com/puzpuzpuz/xsync/v3 v3.5.1 h1:GJYJZwO6IdxN/IKbneznS6yPkVC+c3zyY/j19c++5Fg=
@@ -1077,6 +1075,8 @@ github.com/spiffe/go-spiffe/v2 v2.6.0 h1:l+DolpxNWYgruGQVV0xsfeya3CsC7m8iBzDnMps
 github.com/spiffe/go-spiffe/v2 v2.6.0/go.mod h1:gm2SeUoMZEtpnzPNs2Csc0D/gX33k1xIx7lEzqblHEs=
 github.com/stackitcloud/stackit-sdk-go/core v0.17.3 h1:GsZGmRRc/3GJLmCUnsZswirr5wfLRrwavbnL/renOqg=
 github.com/stackitcloud/stackit-sdk-go/core v0.17.3/go.mod h1:HBCXJGPgdRulplDzhrmwC+Dak9B/x0nzNtmOpu+1Ahg=
+github.com/stolostron/prometheus v0.0.0-20260707114222-c54e4c457006 h1:mvycEpA26VwOYJd9FTA4zLNWtlk9h7Lz5HwCQUchndI=
+github.com/stolostron/prometheus v0.0.0-20260707114222-c54e4c457006/go.mod h1:xXYKzScyqyFHihpS0UsXpC2F3RA/CygOs7wb4mpdusE=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=


### PR DESCRIPTION
## Summary

- Patches **CVE-2026-42151** (GHSA-wg65-39gg-5wfj) — Prometheus Azure AD remote write OAuth `client_secret` exposed in plaintext via the `/-/config` API endpoint (CVSS 7.5 High)
- Uses a `replace` directive pointing to `stolostron/prometheus` with the fix cherry-picked onto v0.308.0, since the upstream fix (v0.311.3) is incompatible with thanos v0.41.0 due to `tsdb/errors` package removal in v0.310.0
- The `stolostron/prometheus` fix branch: [`fix/cve-2026-42151-v0.308.0`](https://github.com/stolostron/prometheus/tree/fix/cve-2026-42151-v0.308.0)

## CVE Details

| Field | Value |
|---|---|
| CVE | [CVE-2026-42151](https://nvd.nist.gov/vuln/detail/CVE-2026-42151) |
| GHSA | [GHSA-wg65-39gg-5wfj](https://github.com/prometheus/prometheus/security/advisories/GHSA-wg65-39gg-5wfj) |
| Severity | High (CVSS 7.5) |
| Module | `github.com/prometheus/prometheus` |
| Affected | v0.308.0 (>= v0.306.0, < v0.311.3) |
| Fix | Upstream v0.311.3 / cherry-picked to stolostron/prometheus |
| Upstream PR | [prometheus/prometheus#18590](https://github.com/prometheus/prometheus/pull/18590) |
| Jira | ACM-36252 |

## govulncheck Results

**Before:** GO-2026-5710 (CVE-2026-42151) found in `github.com/prometheus/prometheus@v0.308.0`

**After:** GO-2026-5710 no longer reported. Remaining findings are Go standard library issues (unrelated).

## Test plan

- [x] `govulncheck ./...` confirms CVE-2026-42151 is resolved
- [x] `go mod tidy && go mod verify` pass
- [x] `go build ./...` succeeds
- [x] `go test ./...` passes