### PR TITLE
fix: patch CVE-2026-42151 in github.com/prometheus/prometheus [rhacm-2.14]

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -156,6 +156,11 @@ require (
 )
 
 replace (
+	// CVE-2026-42151: Azure AD OAuth client_secret exposed via config API.
+	// Upstream fix is in v0.311.3 but requires thanos update (incompatible API changes).
+	// This replace points to katekeiroz-dev/prometheus with the fix cherry-picked onto v2.48.1.
+	github.com/prometheus/prometheus => github.com/katekeiroz-dev/prometheus v0.0.0-20260805114039-08531774f9fc
+
 	github.com/vimeo/galaxycache => github.com/thanos-community/galaxycache v0.0.0-20211122094458-3a32041a1f1e
 	// Overriding to use latest commit.
 	gopkg.in/alecthomas/kingpin.v2 => github.com/alecthomas/kingpin v1.3.8-0.20210301060133-17f40c25f497

--- a/go.mod
+++ b/go.mod
@@ -158,8 +158,8 @@ require (
 replace (
 	// CVE-2026-42151: Azure AD OAuth client_secret exposed via config API.
 	// Upstream fix is in v0.311.3 but requires thanos update (incompatible API changes).
-	// This replace points to katekeiroz-dev/prometheus with the fix cherry-picked onto v2.48.1.
-	github.com/prometheus/prometheus => github.com/katekeiroz-dev/prometheus v0.0.0-20260805114039-08531774f9fc
+	// Fix cherry-picked onto stolostron/prometheus branch cve-2026-42151/v0.48.1 — do not delete branch.
+	github.com/prometheus/prometheus => github.com/stolostron/prometheus v0.0.0-20260805114039-08531774f9fc
 
 	github.com/vimeo/galaxycache => github.com/thanos-community/galaxycache v0.0.0-20211122094458-3a32041a1f1e
 	// Overriding to use latest commit.

--- a/go.sum
+++ b/go.sum
@@ -523,8 +523,6 @@ github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8
 github.com/jung-kurt/gofpdf v1.0.3-0.20190309125859-24315acbbda5/go.mod h1:7Id9E/uU8ce6rXgefFLlgrJj/GYY22cpxn+r32jIOes=
 github.com/karrick/godirwalk v1.8.0/go.mod h1:H5KPZjojv4lE+QYImBI8xVtrBRgYrIVsaRPx4tDPEn4=
 github.com/karrick/godirwalk v1.10.3/go.mod h1:RoGL9dQei4vP9ilrpETWE8CLOZ1kiN0LhBygSwrAsHA=
-github.com/katekeiroz-dev/prometheus v0.0.0-20260805114039-08531774f9fc h1:A84XCaEOq87WZ0cXMf/TQt0EgwiMlRuodPCRTmfGb5I=
-github.com/katekeiroz-dev/prometheus v0.0.0-20260805114039-08531774f9fc/go.mod h1:SRw624aMAxTfryAcP8rOjg4S/sHHaetx2lyJJ2nM83g=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
@@ -707,6 +705,8 @@ github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+github.com/stolostron/prometheus v0.0.0-20260805114039-08531774f9fc h1:3C2NePfKBQPW/I55SsxOFKN640TXsCiTcr5ebO5vdAs=
+github.com/stolostron/prometheus v0.0.0-20260805114039-08531774f9fc/go.mod h1:SRw624aMAxTfryAcP8rOjg4S/sHHaetx2lyJJ2nM83g=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=

--- a/go.sum
+++ b/go.sum
@@ -523,6 +523,8 @@ github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8
 github.com/jung-kurt/gofpdf v1.0.3-0.20190309125859-24315acbbda5/go.mod h1:7Id9E/uU8ce6rXgefFLlgrJj/GYY22cpxn+r32jIOes=
 github.com/karrick/godirwalk v1.8.0/go.mod h1:H5KPZjojv4lE+QYImBI8xVtrBRgYrIVsaRPx4tDPEn4=
 github.com/karrick/godirwalk v1.10.3/go.mod h1:RoGL9dQei4vP9ilrpETWE8CLOZ1kiN0LhBygSwrAsHA=
+github.com/katekeiroz-dev/prometheus v0.0.0-20260805114039-08531774f9fc h1:A84XCaEOq87WZ0cXMf/TQt0EgwiMlRuodPCRTmfGb5I=
+github.com/katekeiroz-dev/prometheus v0.0.0-20260805114039-08531774f9fc/go.mod h1:SRw624aMAxTfryAcP8rOjg4S/sHHaetx2lyJJ2nM83g=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
@@ -676,8 +678,6 @@ github.com/prometheus/procfs v0.7.3/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1
 github.com/prometheus/procfs v0.8.0/go.mod h1:z7EfXMXOkbkqb9IINtpCn86r/to3BnA0uaxHdg830/4=
 github.com/prometheus/procfs v0.11.1 h1:xRC8Iq1yyca5ypa9n1EZnWZkt7dwcoRPQwX/5gwaUuI=
 github.com/prometheus/procfs v0.11.1/go.mod h1:eesXgaPo1q7lBpVMoMy0ZOFTth9hBn4W/y0/p/ScXhY=
-github.com/prometheus/prometheus v0.48.1 h1:CTszphSNTXkuCG6O0IfpKdHcJkvvnAAE1GbELKS+NFk=
-github.com/prometheus/prometheus v0.48.1/go.mod h1:SRw624aMAxTfryAcP8rOjg4S/sHHaetx2lyJJ2nM83g=
 github.com/redis/rueidis v1.0.14-go1.18 h1:dGir5z8w8X1ex7JWO/Zx2FMBrZgQ8Yjm+lw9fPLSNGw=
 github.com/redis/rueidis v1.0.14-go1.18/go.mod h1:HGekzV3HbmzFmRK6j0xic8Z9119+ECoGMjeN1TV1NYU=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=


### PR DESCRIPTION
## Summary

Patches **CVE-2026-42151** (GHSA-wg65-39gg-5wfj) — Prometheus Azure AD remote write OAuth `client_secret` exposed in plaintext via the `/-/config` API endpoint (CVSS 7.5 High).

Uses a `replace` directive pointing to `katekeiroz-dev/prometheus` with the upstream fix ([prometheus/prometheus#18590](https://github.com/prometheus/prometheus/pull/18590)) cherry-picked onto v2.48.1 (Go module v0.48.1).

Direct upgrade to the patched v0.311.3 is incompatible with thanos v0.33.0 due to API changes in the prometheus module (same base as [#248](https://github.com/stolostron/thanos-receive-controller/pull/248) on release-2.16).

The fix branch: [`fix/cve-2026-42151-v0.48.1`](https://github.com/katekeiroz-dev/prometheus/tree/fix/cve-2026-42151-v0.48.1)

## CVE Details

| Field | Value |
|---|---|
| CVE | [CVE-2026-42151](https://nvd.nist.gov/vuln/detail/CVE-2026-42151) |
| GHSA | [GHSA-wg65-39gg-5wfj](https://github.com/prometheus/prometheus/security/advisories/GHSA-wg65-39gg-5wfj) |
| Severity | High (CVSS 7.5) |
| Module | `github.com/prometheus/prometheus` |
| Affected | `>= v0.45.2, < v0.311.3` |
| Fix | Upstream v0.311.3 / cherry-picked to katekeiroz-dev/prometheus v0.48.1 |
| Upstream PR | [prometheus/prometheus#18590](https://github.com/prometheus/prometheus/pull/18590) |
| Jira | ACM-36182 |

## Verification

- [x] `go mod tidy` — clean
- [x] `go mod verify` — all modules verified
- [x] `go build ./...` — compiles
- [x] `go test -race ./...` — passes

Note: `make test` invokes the bingo-managed `promtool` build target, which fails independently of this change with a linker error (`invalid reference to syscall.recvmsg`) building the pinned ancient promtool version against the current Go toolchain — unrelated to this dependency bump. `go test -race ./...` was run directly as a substitute and passes.

Related: ACM-36182

Signed-off-by: Kate Barreiros <kbarreir@redhat.com>

Made with [Cursor](https://cursor.com)