### PR TITLE
fix: add replace directive for prometheus to fix CVE-2026-42151 [rhacm-2.13]

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -160,3 +160,5 @@ replace (
 	// Overriding to use latest commit.
 	gopkg.in/alecthomas/kingpin.v2 => github.com/alecthomas/kingpin v1.3.8-0.20210301060133-17f40c25f497
 )
+
+replace github.com/prometheus/prometheus => github.com/stolostron/prometheus v0.0.0-20260805114039-08531774f9fc

--- a/go.sum
+++ b/go.sum
@@ -669,8 +669,6 @@ github.com/prometheus/procfs v0.7.3/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1
 github.com/prometheus/procfs v0.8.0/go.mod h1:z7EfXMXOkbkqb9IINtpCn86r/to3BnA0uaxHdg830/4=
 github.com/prometheus/procfs v0.11.1 h1:xRC8Iq1yyca5ypa9n1EZnWZkt7dwcoRPQwX/5gwaUuI=
 github.com/prometheus/procfs v0.11.1/go.mod h1:eesXgaPo1q7lBpVMoMy0ZOFTth9hBn4W/y0/p/ScXhY=
-github.com/prometheus/prometheus v0.48.1 h1:CTszphSNTXkuCG6O0IfpKdHcJkvvnAAE1GbELKS+NFk=
-github.com/prometheus/prometheus v0.48.1/go.mod h1:SRw624aMAxTfryAcP8rOjg4S/sHHaetx2lyJJ2nM83g=
 github.com/redis/rueidis v1.0.14-go1.18 h1:dGir5z8w8X1ex7JWO/Zx2FMBrZgQ8Yjm+lw9fPLSNGw=
 github.com/redis/rueidis v1.0.14-go1.18/go.mod h1:HGekzV3HbmzFmRK6j0xic8Z9119+ECoGMjeN1TV1NYU=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
@@ -700,6 +698,8 @@ github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+github.com/stolostron/prometheus v0.0.0-20260805114039-08531774f9fc h1:3C2NePfKBQPW/I55SsxOFKN640TXsCiTcr5ebO5vdAs=
+github.com/stolostron/prometheus v0.0.0-20260805114039-08531774f9fc/go.mod h1:SRw624aMAxTfryAcP8rOjg4S/sHHaetx2lyJJ2nM83g=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=


### PR DESCRIPTION
Patches **CVE-2026-42151** (GHSA-wg65-39gg-5wfj) — Prometheus Azure AD remote write OAuth `client_secret` exposed in plaintext via the `/-/config` API endpoint (CVSS 7.5 High).

Uses a `replace` directive pointing to `stolostron/prometheus` with the upstream fix ([prometheus/prometheus#18590](https://github.com/prometheus/prometheus/pull/18590)) cherry-picked onto v0.48.1 (Go module v0.48.1).

Direct upgrade to the patched v0.311.3 is incompatible with thanos v0.33.0 due to API changes in the prometheus module (same approach as [#250](https://github.com/stolostron/thanos-receive-controller/pull/250) for release-2.14).

Related: ACM-36185